### PR TITLE
Basic authentication support

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -141,6 +141,9 @@ func main() {
 	a.Flag("config.file", "Prometheus configuration file path.").
 		Default("prometheus.yml").StringVar(&cfg.configFile)
 
+	a.Flag("web.basicauth.config", "Information for basic authentication.").
+		Default("").StringVar(&cfg.web.BasicAuthFile)
+
 	a.Flag("web.listen-address", "Address to listen on for UI, API, and telemetry.").
 		Default("0.0.0.0:9090").StringVar(&cfg.web.ListenAddress)
 

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
 	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd
 	github.com/soheilhy/cmux v0.1.4
+	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e

--- a/go.sum
+++ b/go.sum
@@ -568,6 +568,7 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191202143827-86a70503ff7e/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 h1:ULYEB3JvPRE/IfO+9uO7vKV/xzVTO7XPAwm8xbf4w2g=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 h1:vEg9joUBmeBcK9iSJftGNf3coIG4HqZElCPehJsfAYM=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=

--- a/vendor/golang.org/x/crypto/pbkdf2/pbkdf2.go
+++ b/vendor/golang.org/x/crypto/pbkdf2/pbkdf2.go
@@ -1,0 +1,77 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Package pbkdf2 implements the key derivation function PBKDF2 as defined in RFC
+2898 / PKCS #5 v2.0.
+
+A key derivation function is useful when encrypting data based on a password
+or any other not-fully-random data. It uses a pseudorandom function to derive
+a secure encryption key based on the password.
+
+While v2.0 of the standard defines only one pseudorandom function to use,
+HMAC-SHA1, the drafted v2.1 specification allows use of all five FIPS Approved
+Hash Functions SHA-1, SHA-224, SHA-256, SHA-384 and SHA-512 for HMAC. To
+choose, you can pass the `New` functions from the different SHA packages to
+pbkdf2.Key.
+*/
+package pbkdf2 // import "golang.org/x/crypto/pbkdf2"
+
+import (
+	"crypto/hmac"
+	"hash"
+)
+
+// Key derives a key from the password, salt and iteration count, returning a
+// []byte of length keylen that can be used as cryptographic key. The key is
+// derived based on the method described as PBKDF2 with the HMAC variant using
+// the supplied hash function.
+//
+// For example, to use a HMAC-SHA-1 based PBKDF2 key derivation function, you
+// can get a derived key for e.g. AES-256 (which needs a 32-byte key) by
+// doing:
+//
+// 	dk := pbkdf2.Key([]byte("some password"), salt, 4096, 32, sha1.New)
+//
+// Remember to get a good random salt. At least 8 bytes is recommended by the
+// RFC.
+//
+// Using a higher iteration count will increase the cost of an exhaustive
+// search but will also make derivation proportionally slower.
+func Key(password, salt []byte, iter, keyLen int, h func() hash.Hash) []byte {
+	prf := hmac.New(h, password)
+	hashLen := prf.Size()
+	numBlocks := (keyLen + hashLen - 1) / hashLen
+
+	var buf [4]byte
+	dk := make([]byte, 0, numBlocks*hashLen)
+	U := make([]byte, hashLen)
+	for block := 1; block <= numBlocks; block++ {
+		// N.B.: || means concatenation, ^ means XOR
+		// for each block T_i = U_1 ^ U_2 ^ ... ^ U_iter
+		// U_1 = PRF(password, salt || uint(i))
+		prf.Reset()
+		prf.Write(salt)
+		buf[0] = byte(block >> 24)
+		buf[1] = byte(block >> 16)
+		buf[2] = byte(block >> 8)
+		buf[3] = byte(block)
+		prf.Write(buf[:4])
+		dk = prf.Sum(dk)
+		T := dk[len(dk)-hashLen:]
+		copy(U, T)
+
+		// U_n = PRF(password, U_(n-1))
+		for n := 2; n <= iter; n++ {
+			prf.Reset()
+			prf.Write(U)
+			U = U[:0]
+			U = prf.Sum(U)
+			for x := range U {
+				T[x] ^= U[x]
+			}
+		}
+	}
+	return dk[:keyLen]
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -333,6 +333,7 @@ go.opencensus.io/trace/tracestate
 # golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413
 golang.org/x/crypto/ed25519
 golang.org/x/crypto/ed25519/internal/edwards25519
+golang.org/x/crypto/pbkdf2
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/mod v0.2.0
 golang.org/x/mod/module

--- a/web/web.go
+++ b/web/web.go
@@ -16,6 +16,9 @@ package web
 import (
 	"bytes"
 	"context"
+	"crypto/sha512"
+	"crypto/subtle"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -54,6 +57,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/soheilhy/cmux"
+	"golang.org/x/crypto/pbkdf2"
 	"golang.org/x/net/netutil"
 	"google.golang.org/grpc"
 
@@ -84,6 +88,8 @@ var reactRouterPaths = []string{
 	"/tsdb-status",
 	"/version",
 }
+
+var authenticateEnabled = false
 
 // withStackTrace logs the stack trace in case the request panics. The function
 // will re-raise the error which will then be handled by the net/http package.
@@ -241,6 +247,11 @@ type Options struct {
 	RemoteReadSampleLimit      int
 	RemoteReadConcurrencyLimit int
 	RemoteReadBytesInFrame     int
+	BasicAuthFile              string
+	BasicAuthUsername          string
+	BasicAuthHash              string
+	BasicAuthSalt              string
+	BasicAuthIterations        int
 
 	Gatherer   prometheus.Gatherer
 	Registerer prometheus.Registerer
@@ -317,6 +328,13 @@ func New(logger log.Logger, o *Options) *Handler {
 		h.runtimeInfo,
 		h.versionInfo,
 	)
+
+	if h.options.BasicAuthFile != "" {
+		authenticateEnabled = true
+		if h.processBasicAuthFile(h.options.BasicAuthFile) == false {
+			return nil
+		}
+	}
 
 	if o.RoutePrefix != "/" {
 		// If the prefix is missing for the root path, prepend it.
@@ -442,6 +460,30 @@ func New(logger log.Logger, o *Options) *Handler {
 	return h
 }
 
+func (h *Handler) processBasicAuthFile(filename string) bool {
+	type AuthInfo struct {
+		Username string
+		Salt string
+		Hash string
+		Iterations int
+	}
+	var authInfo AuthInfo
+
+	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		fmt.Printf("Error reading auth file '%s': %s", filename, err)
+		return false
+	}
+
+	json.Unmarshal(content, &authInfo)
+	h.options.BasicAuthUsername = authInfo.Username
+	h.options.BasicAuthSalt = authInfo.Salt
+	h.options.BasicAuthHash = authInfo.Hash
+	h.options.BasicAuthIterations = authInfo.Iterations
+
+	return true
+}
+
 func serveDebug(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	subpath := route.Param(ctx, "subpath")
@@ -483,11 +525,46 @@ func (h *Handler) isReady() bool {
 	return ready > 0
 }
 
+func (h *Handler) isAuthenticated(r *http.Request) (bool, string) {
+	if authenticateEnabled == false {
+		return true, ""
+	}
+
+	username, password, ok := r.BasicAuth()
+	if ok == true {
+		hash, err := base64.StdEncoding.DecodeString(h.options.BasicAuthHash)
+		if err != nil {
+			return false, fmt.Sprintf("Error decoding basic auth hash: %s", err)
+		}
+		salt, err := base64.StdEncoding.DecodeString(h.options.BasicAuthSalt)
+		if err != nil {
+			return false, fmt.Sprintf("Error decoding basic auth salt: %s", err)
+		}
+		if username != h.options.BasicAuthUsername {
+			return false, fmt.Sprintf("Invalid user or password")
+		}
+		key := pbkdf2.Key([]byte(password), salt,
+			h.options.BasicAuthIterations, 64, sha512.New)
+		if subtle.ConstantTimeCompare(key, hash) == 0 {
+			return false, fmt.Sprintf("Invalid user or password")
+		}
+	} else {
+		return false, fmt.Sprintf("Error returned by BasicAuth")
+	}
+	return true, ""
+}
+
 // Checks if server is ready, calls f if it is, returns 503 if it is not.
 func (h *Handler) testReady(f http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if h.isReady() {
-			f(w, r)
+			authenticated, err := h.isAuthenticated(r)
+			if authenticated {
+				f(w, r)
+			} else {
+				w.WriteHeader(http.StatusUnauthorized)
+				fmt.Fprintf(w, err)
+			}
 		} else {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			fmt.Fprintf(w, "Service Unavailable")

--- a/web/web.go
+++ b/web/web.go
@@ -462,9 +462,9 @@ func New(logger log.Logger, o *Options) *Handler {
 
 func (h *Handler) processBasicAuthFile(filename string) bool {
 	type AuthInfo struct {
-		Username string
-		Salt string
-		Hash string
+		Username   string
+		Salt       string
+		Hash       string
 		Iterations int
 	}
 	var authInfo AuthInfo


### PR DESCRIPTION
When prometheus is started it can be passed the name of a file
containing information used to do basic authentication of REST requests.

        --web.basicauth.config <file>

The <file> contains the expected username and hash values as well as the
salt and itertions needed to compute the hash.
A REST request is authenticated when the username in the request matches
the expected username and the pbkdf2 generated value matches the
expected has.

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->