### PR TITLE
Allow "reload" and "version" without auth

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -362,7 +362,7 @@ func New(logger log.Logger, o *Options) *Handler {
 	router.Get("/config", readyf(h.serveConfig))
 	router.Get("/rules", readyf(h.rules))
 	router.Get("/targets", readyf(h.targets))
-	router.Get("/version", readyf(h.version))
+	router.Get("/version", h.version)
 	router.Get("/service-discovery", readyf(h.serviceDiscovery))
 
 	router.Get("/metrics", promhttp.Handler().ServeHTTP)
@@ -431,8 +431,8 @@ func New(logger log.Logger, o *Options) *Handler {
 	if o.EnableLifecycle {
 		router.Post("/-/quit", checkAuth(h.quit))
 		router.Put("/-/quit", checkAuth(h.quit))
-		router.Post("/-/reload", checkAuth(h.reload))
-		router.Put("/-/reload", checkAuth(h.reload))
+		router.Post("/-/reload", h.reload)
+		router.Put("/-/reload", h.reload)
 	} else {
 		forbiddenAPINotEnabled := func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusForbidden)


### PR DESCRIPTION
No longer require authentication for the /-/reload REST endpoint to
allow restart of ns_server components which generate a new password.
Otherwise, prometheus will be authenticating using the old password.

Also allow /version without authentication.

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->