### PR TITLE
Fix security hole

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -365,7 +365,7 @@ func New(logger log.Logger, o *Options) *Handler {
 	// Redirect the original React UI's path (under "/new") to its new path at the root.
 	router.Get("/new/*path", func(w http.ResponseWriter, r *http.Request) {
 		p := route.Param(r.Context(), "path")
-		http.Redirect(w, r, path.Join(o.ExternalURL.Path, strings.TrimPrefix(p, "/new"))+"?"+r.URL.RawQuery, http.StatusFound)
+		http.Redirect(w, r, path.Join(o.ExternalURL.Path, p)+"?"+r.URL.RawQuery, http.StatusFound)
 	})
 
 	router.Get("/classic/alerts", readyf(h.alerts))


### PR DESCRIPTION
This change backports a security fix from 2.26.1:

This release contains a bug fix for a security issue in the API endpoint. An
attacker can craft a special URL that redirects a user to any endpoint via an
HTTP 302 response. See the [security advisory][GHSA-vx57-7f4q-fpc7] for more details.

[GHSA-vx57-7f4q-fpc7]:https://github.com/prometheus/prometheus/security/advisories/GHSA-vx57-7f4q-fpc7

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
